### PR TITLE
Do not tab through widgets that are covered by the build pane

### DIFF
--- a/ui/main.slint
+++ b/ui/main.slint
@@ -55,6 +55,9 @@ CargoUI := Window {
 
     VerticalBox {
         TabWidget {
+            // hide the widgets from the tab focus handler when covered:
+            visible: !(is-building || build-pane-visible);
+
             Tab {
                 title: "Project / Workspace";
                 cargo-view := CargoView {


### PR DESCRIPTION
Hide UI that is covered by the build pane. This causes all the widgets to not be considered for tab focus.